### PR TITLE
Adding support for grouped menus

### DIFF
--- a/cascade/src/main/java/me/saket/cascade/CascadeMenuAdapter.kt
+++ b/cascade/src/main/java/me/saket/cascade/CascadeMenuAdapter.kt
@@ -3,24 +3,22 @@
 package me.saket.cascade
 
 import android.annotation.SuppressLint
-import android.view.Menu
 import android.view.MenuItem
 import android.view.SubMenu
 import android.view.ViewGroup
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuItemImpl
 import androidx.appcompat.view.menu.SubMenuBuilder
-import androidx.core.view.iterator
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import me.saket.cascade.CascadePopupMenu.Styler
 import me.saket.cascade.CascadeMenuAdapter.ItemType.Header
 import me.saket.cascade.CascadeMenuAdapter.ItemType.Item
+import me.saket.cascade.CascadePopupMenu.Styler
 import me.saket.cascade.CascadePopupWindow.ThemeAttributes
 
 @SuppressLint("RestrictedApi")
 internal class CascadeMenuAdapter(
-  menu: MenuBuilder,
+  private val menu: MenuBuilder,
   private val styler: Styler,
   private val themeAttrs: ThemeAttributes,
   private val canNavigateBack: Boolean,
@@ -55,7 +53,7 @@ internal class CascadeMenuAdapter(
         itemView.setOnClickListener { onTitleClick(menu) }
       }
       VIEW_TYPE_ITEM -> MenuItemViewHolder.inflate(parent, hasSubMenuItems).apply {
-        itemView.setBackgroundResource(themeAttrs.touchFeedbackRes)
+        contentView.setBackgroundResource(themeAttrs.touchFeedbackRes)
         itemView.setOnClickListener { onItemClick(item) }
       }
       else -> TODO()
@@ -71,10 +69,20 @@ internal class CascadeMenuAdapter(
       }
 
       is MenuItemViewHolder -> {
-        holder.render((items[position] as Item).item)
+        holder.render((items[position] as Item).item, showTopDivider = shouldShowDividerBefore(position))
         styler.menuItem(holder)
       }
     }
+  }
+
+  private fun shouldShowDividerBefore(position: Int): Boolean {
+    if (!menu.isGroupDividerEnabled) {
+      return false
+    }
+
+    val currentItem = (items[position] as Item).item
+    val previousItem = (items.getOrNull(position - 1) as? Item)?.item
+    return previousItem != null && previousItem.groupId != currentItem.groupId
   }
 
   override fun getItemViewType(position: Int): Int {

--- a/cascade/src/main/java/me/saket/cascade/MenuItemViewHolder.kt
+++ b/cascade/src/main/java/me/saket/cascade/MenuItemViewHolder.kt
@@ -4,6 +4,7 @@
 package me.saket.cascade
 
 import android.annotation.SuppressLint
+import android.graphics.drawable.PaintDrawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -32,7 +33,7 @@ class MenuItemViewHolder(
   val contentView: View = view.findViewById(R.id.content)
   val iconView: ImageView by lazy(NONE) { view.findViewById(R.id.icon) }
   val subMenuArrowView: ImageView = view.findViewById(R.id.submenuarrow)
-  val topDivider: ImageView = view.findViewById(R.id.group_divider)
+  val groupDividerView: View = view.findViewById(R.id.group_divider)      // Shown at the top of this item's layout.
 
   lateinit var item: MenuItemImpl
 
@@ -67,6 +68,13 @@ class MenuItemViewHolder(
     iconView.updateMargin(start = if (hasIcon) start else 0, end = 0)
     titleContainerView.updateMargin(start = if (hasIcon) iconSpacing else start)
     contentView.updatePaddingRelative(end = end)
+  }
+
+  fun setGroupDividerColor(color: Int) {
+    // Tinting the divider View is not an option because the default drawable has a transparent color.
+    groupDividerView.background = (groupDividerView.background as? PaintDrawable ?: PaintDrawable()).apply {
+      paint.color = color
+    }
   }
 
   companion object {

--- a/cascade/src/main/java/me/saket/cascade/MenuItemViewHolder.kt
+++ b/cascade/src/main/java/me/saket/cascade/MenuItemViewHolder.kt
@@ -32,18 +32,19 @@ class MenuItemViewHolder(
   val contentView: View = view.findViewById(R.id.content)
   val iconView: ImageView by lazy(NONE) { view.findViewById(R.id.icon) }
   val subMenuArrowView: ImageView = view.findViewById(R.id.submenuarrow)
+  val topDivider: ImageView = view.findViewById(R.id.group_divider)
 
   lateinit var item: MenuItemImpl
 
   private val Int.dip: Int
     get() = view.context.dip(this)
 
-  fun render(item: MenuItemImpl) {
+  fun render(item: MenuItemImpl, showTopDivider: Boolean = false) {
     this.item = item
 
     view.setForceShowIcon(true)
     view.initialize(this.item, 0)
-    view.setGroupDividerEnabled(false)
+    view.setGroupDividerEnabled(showTopDivider)
 
     if (this.item.hasSubMenu()) {
       subMenuArrowView.setImageResource(R.drawable.cascade_ic_round_arrow_right_24)

--- a/cascade/src/main/java/me/saket/cascade/ktx.kt
+++ b/cascade/src/main/java/me/saket/cascade/ktx.kt
@@ -1,8 +1,11 @@
+@file:Suppress("unused")
+
 package me.saket.cascade
 
 import android.view.Menu
 import android.view.MenuItem
-import androidx.core.view.children
+import android.view.SubMenu
+import androidx.annotation.StringRes
 import androidx.core.view.iterator
 
 // ==================================================================
@@ -26,3 +29,39 @@ val Menu.allChildren: List<MenuItem>
       }
     }
   }
+
+fun Menu.add(
+  title: CharSequence,
+  itemId: Int = Menu.NONE,
+  groupId: Int = Menu.NONE,
+  order: Int = Menu.NONE
+): MenuItem {
+  return add(groupId, itemId, order, title)
+}
+
+fun Menu.add(
+  @StringRes titleRes: Int,
+  itemId: Int = Menu.NONE,
+  groupId: Int = Menu.NONE,
+  order: Int = Menu.NONE
+): MenuItem {
+  return add(groupId, itemId, order, titleRes)
+}
+
+fun Menu.addSubMenu(
+  title: CharSequence,
+  groupId: Int = Menu.NONE,
+  itemId: Int = Menu.NONE,
+  order: Int = Menu.NONE
+): SubMenu {
+  return addSubMenu(groupId, itemId, order, title)
+}
+
+fun Menu.addSubMenu(
+  @StringRes titleRes: Int,
+  groupId: Int = Menu.NONE,
+  itemId: Int = Menu.NONE,
+  order: Int = Menu.NONE
+): SubMenu {
+  return addSubMenu(groupId, itemId, order, titleRes)
+}

--- a/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
+++ b/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
@@ -10,8 +10,6 @@ import android.graphics.drawable.RippleDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.util.TypedValue
-import android.view.Menu
-import android.view.MenuItem
 import android.view.SubMenu
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -19,12 +17,13 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
-import androidx.core.view.iterator
+import androidx.core.view.MenuCompat
 import androidx.core.view.postDelayed
 import com.getkeepsafe.taptargetview.TapTarget
 import com.getkeepsafe.taptargetview.TapTargetView
 import com.getkeepsafe.taptargetview.TapTargetView.Listener
 import me.saket.cascade.CascadePopupMenu
+import me.saket.cascade.add
 import me.saket.cascade.allChildren
 
 class MainActivity : AppCompatActivity() {
@@ -46,8 +45,10 @@ class MainActivity : AppCompatActivity() {
   private fun showCascadeMenu(anchor: View) {
     val popupMenu = CascadePopupMenu(this, anchor, styler = cascadeMenuStyler())
     popupMenu.menu.apply {
-      add("About").setIcon(R.drawable.ic_language_24)
-      add("Copy").setIcon(R.drawable.ic_file_copy_24)
+      add("About", groupId = 42).setIcon(R.drawable.ic_language_24)
+      add("Copy", groupId = 42).setIcon(R.drawable.ic_file_copy_24)
+      MenuCompat.setGroupDividerEnabled(this, true)
+
       addSubMenu("Share").also {
         val addShareTargets = { sub: SubMenu ->
           sub.add("PDF")
@@ -102,7 +103,7 @@ class MainActivity : AppCompatActivity() {
       },
       menuItem = {
         it.titleView.typeface = ResourcesCompat.getFont(this, R.font.work_sans_medium)
-        it.itemView.background = rippleDrawable()
+        it.contentView.background = rippleDrawable()
       }
     )
   }

--- a/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
+++ b/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
@@ -45,10 +45,10 @@ class MainActivity : AppCompatActivity() {
   private fun showCascadeMenu(anchor: View) {
     val popupMenu = CascadePopupMenu(this, anchor, styler = cascadeMenuStyler())
     popupMenu.menu.apply {
-      add("About", groupId = 42).setIcon(R.drawable.ic_language_24)
-      add("Copy", groupId = 42).setIcon(R.drawable.ic_file_copy_24)
       MenuCompat.setGroupDividerEnabled(this, true)
 
+      add("About").setIcon(R.drawable.ic_language_24)
+      add("Copy").setIcon(R.drawable.ic_file_copy_24)
       addSubMenu("Share").also {
         val addShareTargets = { sub: SubMenu ->
           sub.add("PDF")
@@ -56,8 +56,8 @@ class MainActivity : AppCompatActivity() {
           sub.add("Image")
           sub.add("Web page")
           sub.add("Markdown")
-          sub.add("Plain text")
-          sub.add("Microsoft word")
+          sub.add("Plain text", groupId = 42)
+          sub.add("Microsoft word", groupId = 42)
         }
         it.setIcon(R.drawable.ic_share_24)
         addShareTargets(it.addSubMenu("To clipboard"))

--- a/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
+++ b/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
@@ -104,6 +104,7 @@ class MainActivity : AppCompatActivity() {
       menuItem = {
         it.titleView.typeface = ResourcesCompat.getFont(this, R.font.work_sans_medium)
         it.contentView.background = rippleDrawable()
+        it.setGroupDividerColor(Color.parseColor("#BED9CF"))
       }
     )
   }


### PR DESCRIPTION
Implementing #1 

### Demo:
<img src="https://user-images.githubusercontent.com/4093820/95676619-d76cb800-0bd8-11eb-928e-2cf1042d8784.gif" width="300"/>

### TODO:
1. `setGroupVisible` currently hides the group but does not adjust the menu height.
2. Adding support for `setGroupCheckable`.
3. `setGroupEnabled` is functional but the group state stays the same. (Perhaps we could add color states for disabled items)

Also, it'd be nice to add icons for the sample grouped menu items. I can add them if there's an icon set you've already used for the other items that I can have access to.
