### PR TITLE
Feature/menu groups support

### DIFF
--- a/cascade/src/main/java/me/saket/cascade/CascadePopupMenu.kt
+++ b/cascade/src/main/java/me/saket/cascade/CascadePopupMenu.kt
@@ -22,6 +22,7 @@ import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuItemImpl
 import androidx.appcompat.view.menu.SubMenuBuilder
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import java.util.Stack
@@ -81,6 +82,32 @@ open class CascadePopupMenu @JvmOverloads constructor(
       val currentMenu = backstack.pop() as SubMenuBuilder
       showMenu(currentMenu.parentMenu, goingForward = false)
     }
+  }
+
+  /**
+   * Adds a MenuItem to the given groupId with the given titleId.
+   * @param groupId: the id of the group that the MenuItem belongs to.
+   * @param titleId: the id of the title.
+   */
+  fun addToGroup(groupId: Int, titleId: Int) {
+    menu.add(groupId, ViewCompat.generateViewId(), Menu.NONE, titleId)
+  }
+
+  /**
+   * Adds a MenuItem to the given groupId with the given title.
+   * @param groupId: the id of the group that the MenuItem belongs to.
+   * @param title: the title as CharSequence.
+   */
+  fun addToGroup(groupId: Int, title: CharSequence) {
+    menu.add(groupId, ViewCompat.generateViewId(), Menu.NONE, title)
+  }
+
+  /**
+   * Removes the MenuItem(s) of the given groupId.
+   * @param groupId: the id of the group of which the elements will be removed.
+   */
+  fun removeGroup(groupId: Int) {
+    menu.removeGroup(groupId)
   }
 
   private fun showMenu(menu: Menu, goingForward: Boolean) {

--- a/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
+++ b/sample/src/main/java/me/saket/cascade/sample/MainActivity.kt
@@ -46,6 +46,8 @@ class MainActivity : AppCompatActivity() {
 
   private fun showCascadeMenu(anchor: View) {
     val popupMenu = CascadePopupMenu(this, anchor, styler = cascadeMenuStyler())
+    popupMenu.addToGroup(groupId = R.id.group_support, title = "Call")
+    popupMenu.addToGroup(groupId = R.id.group_support, title = "Mail")
     popupMenu.menu.apply {
       add("About").setIcon(R.drawable.ic_language_24)
       add("Copy").setIcon(R.drawable.ic_file_copy_24)
@@ -86,6 +88,7 @@ class MainActivity : AppCompatActivity() {
         }
       }
 
+      popupMenu.removeGroup(R.id.group_support)
       popupMenu.show()
     }
   }

--- a/sample/src/main/res/menu/toolbar.xml
+++ b/sample/src/main/res/menu/toolbar.xml
@@ -9,4 +9,6 @@
     android:icon="@drawable/ic_more_vert_24"
     android:title="Menu"
     app:showAsAction="always" />
+
+  <group android:id="@+id/group_support" />
 </menu>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
   <string name="app_name">Cascade</string>
+  <string name="support_call">Call</string>
+  <string name="support_mail">Mail</string>
 </resources>


### PR DESCRIPTION
This PR addresses the issue #1 .

### `addToGroup()` example:
![Screenshot_1602413595](https://user-images.githubusercontent.com/33685811/95676759-e6e00700-0bc0-11eb-945f-fc80070d666d.png)

### `removeFromGroup()` example:
![Screenshot_1602413616](https://user-images.githubusercontent.com/33685811/95676761-e9daf780-0bc0-11eb-95a6-a755796f42ba.png)

###### Note: The `setGroupVisible()` method is not implemented as it sets the visibility of MenuItems without removing the space. One possible workaround would be to call `removeFromGroup()` method when the user calls `setGroupVisible(false)` and `addToGroup()` method when the user calls `setGroupVisible(false)`. To be able to implement this, though, we should memorize the MenuItems added locally before removing them in order to recreate them when `setGroupVisible(false)` is called. Consequently, this would be a duplicate implementation of the existing `addToGroup()` and `removeFromGroup()` methods.
