### PR TITLE
Use custom EventDelegate on API 22

### DIFF
--- a/cascade/src/main/java/me/saket/cascade/CascadePopupWindow.kt
+++ b/cascade/src/main/java/me/saket/cascade/CascadePopupWindow.kt
@@ -8,6 +8,8 @@ import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.LOLLIPOP
+import android.os.Build.VERSION_CODES.LOLLIPOP_MR1
 import android.view.Gravity
 import android.view.View
 import android.widget.PopupMenu
@@ -54,10 +56,10 @@ open class CascadePopupWindow @JvmOverloads constructor(
       background = themeAttrs.popupBackground
       clipToOutline = true
 
-      if (SDK_INT == 21) {
+      if (SDK_INT == LOLLIPOP || SDK_INT == LOLLIPOP_MR1) {
         @SuppressLint("NewApi") // Was @hide on old API levels. Shouldn't be an actual issue.
         isTouchModal = true
-        eventDelegate = Api21EventDelegate(onDismiss = ::dismiss)
+        eventDelegate = LollipopEventDelegate(onDismiss = ::dismiss)
       }
     }
   }

--- a/cascade/src/main/java/me/saket/cascade/CascadePopupWindow.kt
+++ b/cascade/src/main/java/me/saket/cascade/CascadePopupWindow.kt
@@ -8,8 +8,6 @@ import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.LOLLIPOP
-import android.os.Build.VERSION_CODES.LOLLIPOP_MR1
 import android.view.Gravity
 import android.view.View
 import android.widget.PopupMenu
@@ -56,10 +54,10 @@ open class CascadePopupWindow @JvmOverloads constructor(
       background = themeAttrs.popupBackground
       clipToOutline = true
 
-      if (SDK_INT == LOLLIPOP || SDK_INT == LOLLIPOP_MR1) {
+      if (SDK_INT == 21 || SDK_INT == 22) {
         @SuppressLint("NewApi") // Was @hide on old API levels. Shouldn't be an actual issue.
         isTouchModal = true
-        eventDelegate = LollipopEventDelegate(onDismiss = ::dismiss)
+        eventDelegate = Api21And22EventDelegate(onDismiss = ::dismiss)
       }
     }
   }

--- a/cascade/src/main/java/me/saket/cascade/EventDelegate.kt
+++ b/cascade/src/main/java/me/saket/cascade/EventDelegate.kt
@@ -17,11 +17,11 @@ interface EventDelegate {
 class NoOpEventDelegate : EventDelegate
 
 /**
- * On API 21, PopupWindow only handles touch and key events if a background is present.
+ * On API 21 & 22, PopupWindow only handles touch and key events if a background is present.
  * Cascade draws its (animatable) background manually so the events must be handled manually.
  */
 @SuppressLint("ViewConstructor")
-class Api21EventDelegate(private val onDismiss: () -> Unit) : EventDelegate {
+class LollipopEventDelegate(private val onDismiss: () -> Unit) : EventDelegate {
   override fun dispatchKeyEvent(event: KeyEvent): Boolean {
     return if (event.keyCode == KEYCODE_BACK && event.action == ACTION_UP && !event.isCanceled) {
       onDismiss()

--- a/cascade/src/main/java/me/saket/cascade/EventDelegate.kt
+++ b/cascade/src/main/java/me/saket/cascade/EventDelegate.kt
@@ -21,7 +21,7 @@ class NoOpEventDelegate : EventDelegate
  * Cascade draws its (animatable) background manually so the events must be handled manually.
  */
 @SuppressLint("ViewConstructor")
-class LollipopEventDelegate(private val onDismiss: () -> Unit) : EventDelegate {
+class Api21And22EventDelegate(private val onDismiss: () -> Unit) : EventDelegate {
   override fun dispatchKeyEvent(event: KeyEvent): Boolean {
     return if (event.keyCode == KEYCODE_BACK && event.action == ACTION_UP && !event.isCanceled) {
       onDismiss()


### PR DESCRIPTION
The behavior on API 21(LOLLIPOP) which requires a custom event delegate actually extends to API 22(LOLLIPOP_MR1).