### PR TITLE
Make fixedWidth a function.

### DIFF
--- a/cascade/src/main/java/me/saket/cascade/CascadePopupMenu.kt
+++ b/cascade/src/main/java/me/saket/cascade/CascadePopupMenu.kt
@@ -35,7 +35,7 @@ open class CascadePopupMenu @JvmOverloads constructor(
   private val anchor: View,
   private var gravity: Int = Gravity.NO_GRAVITY,
   private val styler: Styler = Styler(),
-  private val fixedWidth: Int = context.dip(196),
+  private val fixedWidth: (Menu) -> Int = { context.dip(196) },
   private val defStyleAttr: Int = android.R.style.Widget_Material_PopupMenu,
   private val backNavigator: CascadeBackNavigator = CascadeBackNavigator()
 ) {
@@ -72,7 +72,7 @@ open class CascadePopupMenu @JvmOverloads constructor(
     // PopupWindow moves the popup to align with the anchor if a fixed width
     // is known before hand. Note to self: If fixedWidth ever needs to be
     // removed, copy over MenuPopup.measureIndividualMenuWidth().
-    popup.width = fixedWidth
+    popup.width = fixedWidth(menu)
     popup.height = WRAP_CONTENT // Doesn't work on API 21 without this.
 
     popup.setMargins(


### PR DESCRIPTION
The width of the popup is currently fixed and while this is fine in a single-language project, translations often lead to truncated texts in the popup.

The change in the PR simply makes the `fixedWidth` property a function and provides the menu as a parameter so users get the chance to calculate the width before the popup is shown.

Currently, for my use case, I loop through the menu items and find the item with the largest width. 

Note that in cases where I inflate the menu on cascade myself before calling `show()` then I can already do this calculation before creating cascade even though that would mean inflating a dummy menu outside since `fixedWidth` is a constructor parameter so I can't use the menu inside cascade. However, since I also use cascade to override the toolbar's popup menu, grabbing the inflated menu before it is shown becomes a problem because all the work is done in the `toolbar.kt`

Granted, this would be considered a breaking change but it is one that is quite easy to fix, and users who do not set a custom value for this parameter do not even need to do anything.