### PR TITLE
Use Java 11 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: gradle/wrapper-validation-action@v1      
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Run build
       run: ./gradlew build


### PR DESCRIPTION
AGP 7.1.x requires a Java 11 runtime
