### PR TITLE
Fix Crash: Cascade with Jetpack Compose 1.5.0+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
     minSdk: 23,
     compileSdk: 33,
     kotlin: '1.8.21',
-    composeUi: '1.5.0-alpha04',
+    composeUi: '1.5.0-alpha01',
     composeCompiler: '1.4.7',
-    composeUiMaterial3: '1.2.0-alpha01',
+    composeUiMaterial3: '1.1.0',
     appCompat: '1.5.1',
     testParamInjector: '1.10',
   ]
@@ -35,6 +35,6 @@ allprojects {
   }
 }
 
-tasks.register('clean', Delete) {
+task clean(type: Delete) {
   delete rootProject.buildDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ buildscript {
   ext.versions = [
     minSdk: 23,
     compileSdk: 33,
-    kotlin: '1.8.10',
-    composeUi: '1.4.3',
-    composeCompiler: '1.4.4',
+    kotlin: '1.8.21',
+    composeUi: '1.5.0-alpha04',
+    composeCompiler: '1.4.7',
     composeUiMaterial3: '1.2.0-alpha01',
     appCompat: '1.5.1',
     testParamInjector: '1.10',
@@ -35,6 +35,6 @@ allprojects {
   }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
   delete rootProject.buildDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ buildscript {
   ext.versions = [
     minSdk: 23,
     compileSdk: 33,
-    kotlin: '1.7.20',
-    composeUi: '1.3.1',
-    composeCompiler: '1.4.0-alpha01',
-    composeUiMaterial3: '1.0.1',
+    kotlin: '1.8.10',
+    composeUi: '1.4.3',
+    composeCompiler: '1.4.4',
+    composeUiMaterial3: '1.2.0-alpha01',
     appCompat: '1.5.1',
     testParamInjector: '1.10',
   ]

--- a/cascade-compose/src/main/java/me/saket/cascade/Cascade.kt
+++ b/cascade-compose/src/main/java/me/saket/cascade/Cascade.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalAnimationApi::class, ExperimentalComposeUiApi::class)
+@file:OptIn(ExperimentalAnimationApi::class)
 
 package me.saket.cascade
 
@@ -48,7 +48,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment.Companion.CenterVertically
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -246,7 +245,8 @@ private fun CascadeDropdownMenuContent(
     AnimatedContent(
       modifier = modifier,
       targetState = backStackSnapshot,
-      transitionSpec = { cascadeTransitionSpec(layoutDirection) }
+      transitionSpec = { cascadeTransitionSpec(layoutDirection) },
+      label = "cascadeAnimation"
     ) { snapshot ->
       Column(
         Modifier

--- a/cascade-compose/src/main/java/me/saket/cascade/internal/cascadeTransitionSpec.kt
+++ b/cascade-compose/src/main/java/me/saket/cascade/internal/cascadeTransitionSpec.kt
@@ -1,10 +1,7 @@
-@file:OptIn(ExperimentalAnimationApi::class)
-
 package me.saket.cascade.internal
 
-import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
@@ -13,8 +10,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.LayoutDirection.Ltr
 import me.saket.cascade.BackStackSnapshot
 
-@OptIn(ExperimentalAnimationApi::class)
-internal fun AnimatedContentScope<BackStackSnapshot>.cascadeTransitionSpec(
+internal fun AnimatedContentTransitionScope<BackStackSnapshot>.cascadeTransitionSpec(
   layoutDirection: LayoutDirection
 ): ContentTransform {
   val navigatingForward = targetState.backStackSize > initialState.backStackSize


### PR DESCRIPTION
Latest alpha release of Material3 transitively updates Compose to 1.5.0-alpha04 and it has some breaking changes, hence the crash (mentioned in #36).
