### PR TITLE
added consumer-rules.pro for consumer proguard rules

### DIFF
--- a/sample/consumer-rules.pro
+++ b/sample/consumer-rules.pro
@@ -1,0 +1,6 @@
+-keepclassmembers class androidx.appcompat.view.menu.MenuBuilder {
+    private *** mPresenters;
+}
+-keep class androidx.appcompat.widget.ActionMenuPresenter {
+    *;
+}


### PR DESCRIPTION
Includes `consumer-rules.pro` for:

https://github.com/saket/cascade/blob/80fcf2dab77b0413b3bb420600b5fb947080417b/cascade/src/main/java/me/saket/cascade/toolbar.kt#L122

and 

https://github.com/saket/cascade/blob/80fcf2dab77b0413b3bb420600b5fb947080417b/cascade/src/main/java/me/saket/cascade/toolbar.kt#L134
